### PR TITLE
MovementBuilder Re-use bug (fix)

### DIFF
--- a/epymorph/movement/dynamic.py
+++ b/epymorph/movement/dynamic.py
@@ -244,17 +244,16 @@ class DynamicMovementBuilder(MovementBuilder):
         # results = movement_spec.parse_string(spec_string, parse_all=True)
         # spec: MovementSpec = results[0]  # type: ignore
 
-        if self.namespace is None:
-            namespace = make_global_namespace(ctx)
+        namespace = make_global_namespace(ctx)
 
-            # t0 = time.perf_counter()
-            predef = {} if self.spec.predef is None else \
-                execute_predef(self.spec.predef, namespace)
-            # t1 = time.perf_counter()
-            # print(f"Executed predef in {(1000 * (t1 - t0)):.3f} ms")
+        # t0 = time.perf_counter()
+        predef = {} if self.spec.predef is None else \
+            execute_predef(self.spec.predef, namespace)
+        # t1 = time.perf_counter()
+        # print(f"Executed predef in {(1000 * (t1 - t0)):.3f} ms")
 
-            namespace = namespace | {'predef': predef}
-            self.namespace = namespace
+        namespace = namespace | {'predef': predef}
+        self.namespace = namespace
 
         if self.compilers is None:
             self.compilers = [to_clause_compiler(c) for c in self.spec.clauses]


### PR DESCRIPTION
Fixed bug from Issue #58
Running two simulations would result in an error if second simulation had more nodes. 
DynamicMovementBuilder was caching ctx from the first sim and using it for the second sim.
Forcing it to assign sim data every time instead of only when it is none solves this issue.