### PR TITLE
Fix issues adapting shapes and add test cases.

### DIFF
--- a/epymorph/data_shape.py
+++ b/epymorph/data_shape.py
@@ -67,14 +67,14 @@ class Time(DataShape):
     """An array of at least size T (the number of simulation days)."""
 
     def matches(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> bool:
-        if len(value.shape) == 1 and value.shape[0] >= dim.days:
+        if value.ndim == 1 and value.shape[0] >= dim.days:
             return True
         if allow_broadcast and value.shape == tuple():
             return True
         return False
 
     def adapt(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> NDArray | None:
-        if len(value.shape) == 1 and value.shape[0] >= dim.days:
+        if value.ndim == 1 and value.shape[0] >= dim.days:
             return value[:dim.days]
         if allow_broadcast and value.shape == tuple():
             return np.broadcast_to(value, shape=(dim.days,))
@@ -95,14 +95,14 @@ class Node(DataShape):
     """An array of size N (the number of simulation nodes)."""
 
     def matches(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> bool:
-        if len(value.shape) == 1 and value.shape[0] == dim.nodes:
+        if value.ndim == 1 and value.shape[0] == dim.nodes:
             return True
         if allow_broadcast and value.shape == tuple():
             return True
         return False
 
     def adapt(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> NDArray | None:
-        if len(value.shape) == 1 and value.shape[0] == dim.nodes:
+        if value.ndim == 1 and value.shape[0] == dim.nodes:
             return value
         if allow_broadcast and value.shape == tuple():
             return np.broadcast_to(value, shape=(dim.nodes,))
@@ -152,26 +152,26 @@ class TimeAndNode(DataShape):
     """An array of size at-least-T by exactly-N."""
 
     def matches(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> bool:
-        if len(value.shape) == 2 and value.shape[0] >= dim.days and value.shape[1] == dim.nodes:
+        if value.ndim == 2 and value.shape[0] >= dim.days and value.shape[1] == dim.nodes:
             return True
         if allow_broadcast:
             if value.shape == tuple():
                 return True
             if value.shape == (dim.nodes,):
                 return True
-            if len(value.shape) == 1 and value.shape[0] >= dim.days:
+            if value.ndim == 1 and value.shape[0] >= dim.days:
                 return True
         return False
 
     def adapt(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> NDArray | None:
-        if len(value.shape) == 2 and value.shape[0] >= dim.days and value.shape[1] == dim.nodes:
+        if value.ndim == 2 and value.shape[0] >= dim.days and value.shape[1] == dim.nodes:
             return value[:dim.days, :]
         if allow_broadcast:
             if value.shape == tuple():
                 return np.broadcast_to(value, shape=(dim.days, dim.nodes))
             if value.shape == (dim.nodes,):
                 return np.broadcast_to(value, shape=(dim.days, dim.nodes))
-            if len(value.shape) == 1 and value.shape[0] >= dim.days:
+            if value.ndim == 1 and value.shape[0] >= dim.days:
                 return np.broadcast_to(value[:dim.days, np.newaxis], shape=(dim.days, dim.nodes))
         return None
 
@@ -196,12 +196,12 @@ class Arbitrary(DataShape):
             raise ValueError("Arbitrary shape cannot specify negative indices.")
 
     def matches(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> bool:
-        if len(value.shape) == 1 and value.shape[0] > self.index:
+        if value.ndim == 1 and value.shape[0] > self.index:
             return True
         return False
 
     def adapt(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> NDArray | None:
-        if len(value.shape) == 1 and value.shape[0] > self.index:
+        if value.ndim == 1 and value.shape[0] > self.index:
             return value
         return None
 
@@ -231,21 +231,19 @@ class TimeAndArbitrary(DataShape):
             raise ValueError("Arbitrary shape cannot specify negative indices.")
 
     def matches(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> bool:
-        a = value.shape[-1]
-        if len(value.shape) == 2 and value.shape[0] >= dim.days and a > self.index:
+        if value.ndim == 2 and value.shape[0] >= dim.days and value.shape[1] > self.index:
             return True
         if allow_broadcast:
-            if len(value.shape) == 1 and a > self.index:
+            if value.ndim == 1 and value.shape[0] > self.index:
                 return True
         return False
 
     def adapt(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> NDArray | None:
-        a = value.shape[-1]
-        if len(value.shape) == 2 and value.shape[0] >= dim.days and a > self.index:
+        if value.ndim == 2 and value.shape[0] >= dim.days and value.shape[1] > self.index:
             return value[:dim.days, :]
         if allow_broadcast:
-            if len(value.shape) == 1 and a > self.index:
-                return np.broadcast_to(value, shape=(dim.days, a))
+            if value.ndim == 1 and value.shape[0] > self.index:
+                return np.broadcast_to(value, shape=(dim.days, value.shape[0]))
         return None
 
     def as_tuple(self, nodes: int, days: int) -> tuple[int, ...]:
@@ -269,21 +267,19 @@ class NodeAndArbitrary(DataShape):
             raise ValueError("Arbitrary shape cannot specify negative indices.")
 
     def matches(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> bool:
-        a = value.shape[-1]
-        if len(value.shape) == 2 and value.shape[0] == dim.nodes and a > self.index:
+        if value.ndim == 2 and value.shape[0] == dim.nodes and value.shape[1] > self.index:
             return True
         if allow_broadcast:
-            if len(value.shape) == 1 and a > self.index:
+            if value.ndim == 1 and value.shape[0] > self.index:
                 return True
         return False
 
     def adapt(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> NDArray | None:
-        a = value.shape[-1]
-        if len(value.shape) == 2 and value.shape[0] == dim.nodes and a > self.index:
+        if value.ndim == 2 and value.shape[0] == dim.nodes and value.shape[1] > self.index:
             return value
         if allow_broadcast:
-            if len(value.shape) == 1 and a > self.index:
-                return np.broadcast_to(value, shape=(dim.nodes, a))
+            if value.ndim == 1 and value.shape[0] > self.index:
+                return np.broadcast_to(value, shape=(dim.nodes, value.shape[0]))
         return None
 
     def as_tuple(self, nodes: int, days: int) -> tuple[int, ...]:
@@ -307,28 +303,28 @@ class TimeAndNodeAndArbitrary(DataShape):
             raise ValueError("Arbitrary shape cannot specify negative indices.")
 
     def matches(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> bool:
-        a = value.shape[-1]
-        if len(value.shape) == 3 and value.shape[0] >= dim.days and value.shape[1] == dim.nodes and a > self.index:
+        if value.ndim == 3 and value.shape[0] >= dim.days and value.shape[1] == dim.nodes and value.shape[2] > self.index:
             return True
-        if allow_broadcast:
-            if len(value.shape) == 1 and a > self.index:
+        if allow_broadcast and value.ndim > 0:
+            a = value.shape[-1]
+            if value.ndim == 1 and a > self.index:
                 return True
-            if len(value.shape) == 2 and value.shape[0] == dim.nodes and a > self.index:
+            if value.ndim == 2 and value.shape[0] == dim.nodes and a > self.index:
                 return True
-            if len(value.shape) == 2 and value.shape[0] >= dim.days and a > self.index:
+            if value.ndim == 2 and value.shape[0] >= dim.days and a > self.index:
                 return True
         return False
 
     def adapt(self, dim: SimDimensions, value: NDArray, allow_broadcast: bool) -> NDArray | None:
-        a = value.shape[-1]
-        if len(value.shape) == 3 and value.shape[0] >= dim.days and value.shape[1] == dim.nodes and a > self.index:
+        if value.ndim == 3 and value.shape[0] >= dim.days and value.shape[1] == dim.nodes and value.shape[2] > self.index:
             return value[:dim.days, :, :]
-        if allow_broadcast:
-            if len(value.shape) == 1 and a > self.index:
+        if allow_broadcast and value.ndim > 0:
+            a = value.shape[-1]
+            if value.ndim == 1 and a > self.index:
                 return np.broadcast_to(value, shape=(dim.days, dim.nodes, a))
-            if len(value.shape) == 2 and value.shape[0] == dim.nodes and a > self.index:
+            if value.ndim == 2 and value.shape[0] == dim.nodes and a > self.index:
                 return np.broadcast_to(value, shape=(dim.days, dim.nodes, a))
-            if len(value.shape) == 2 and value.shape[0] >= dim.days and a > self.index:
+            if value.ndim == 2 and value.shape[0] >= dim.days and a > self.index:
                 return np.broadcast_to(value[:dim.days, np.newaxis, :], shape=(dim.days, dim.nodes, a))
         return None
 

--- a/epymorph/test/data_shape_test.py
+++ b/epymorph/test/data_shape_test.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-docstring
 import unittest
+from functools import reduce
+from typing import Any, TypeGuard, TypeVar
 
 import numpy as np
 
@@ -15,8 +17,18 @@ _dim = SimDimensions.build(
     events=2
 )
 
+T = TypeVar('T')
+
+
+def shaped_arange(shape: tuple[int, ...]):
+    return np.arange(reduce(lambda a, b: a * b, shape)).reshape(shape)
+
 
 class DataShape(unittest.TestCase):
+    def assert_not_none(self, val: T | None, msg: Any | None = None) -> TypeGuard[T]:
+        self.assertIsNotNone(val, msg)
+        return True
+
     def as_bool_asserts(self, test_fn):
         def ttt(*args, **kwargs):
             return self.assertTrue(test_fn(*args, **kwargs))
@@ -159,6 +171,250 @@ class DataShape(unittest.TestCase):
                 _dim, np.arange(90 * 6 * 2).reshape((90, 6, 2)), False
             )
         )
+
+    def adapt_test_framework(self, shape, cases):
+        for i, (input_value, broadcast, expected) in enumerate(cases):
+            error = f"Failure in test case {i}: ({shape}, {input_value}, {broadcast}, {expected})"
+            actual = shape.adapt(_dim, input_value, broadcast)
+            if expected is None:
+                self.assertIsNone(actual, error)
+            elif self.assert_not_none(actual, error):
+                np.testing.assert_array_equal(actual, expected, error)
+
+    def test_adapt_scalar(self):
+        self.adapt_test_framework(Shapes.S, [
+            # Test S
+            (np.asarray(42.0), True, np.asarray(42.0)),
+            (np.asarray(42.0), False, np.asarray(42.0)),
+            # Test higher dimensions
+            (np.asarray([42.0, 43.0, 44.0]), True, None),
+            (np.asarray([42.0, 43.0, 44.0]), False, None),
+            (np.asarray([[42.0, 43.0, 44.0], [1.0, 2.0, 3.0]]), True, None),
+            (np.asarray([[42.0, 43.0, 44.0], [1.0, 2.0, 3.0]]), False, None),
+        ])
+
+    def test_adapt_node(self):
+        node_values = np.asarray([41.0, 42.0, 43.0, 44.0, 45.0, 46.0])
+        self.adapt_test_framework(Shapes.N, [
+            # Test S
+            (np.asarray(42.0), True, np.full(_dim.nodes, 42.0)),
+            (np.asarray(42.0), False, None),
+            # Test N
+            (node_values.copy(), True, node_values),
+            (node_values.copy(), False, node_values),
+            # Test < N
+            (np.arange(3), True, None),
+            (np.arange(3), False, None),
+            # Test > N
+            (np.arange(30), True, None),
+            (np.arange(30), False, None),
+            # Test NxN
+            (np.arange(_dim.nodes * _dim.nodes).reshape((_dim.nodes, _dim.nodes)), True, None),
+            (np.arange(_dim.nodes * _dim.nodes).reshape((_dim.nodes, _dim.nodes)), False, None),
+            # Test higher dimension
+            (np.asarray([[42.0, 43.0, 44.0], [1.0, 2.0, 3.0]]), True, None),
+            (np.asarray([[42.0, 43.0, 44.0], [1.0, 2.0, 3.0]]), False, None),
+        ])
+
+    def test_adapt_time(self):
+        time_values = np.arange(_dim.days) + 40
+        self.adapt_test_framework(Shapes.T, [
+            # Test S
+            (np.asarray(42.0), True, np.full(_dim.days, 42.0)),
+            (np.asarray(42.0), False, None),
+            # Test T
+            (time_values.copy(), True, time_values),
+            (time_values.copy(), False, time_values),
+            # Test < T
+            (np.arange(40) * 7, True, None),
+            (np.arange(40) * 7, False, None),
+            # Test > T
+            (np.arange(200) * 13, True, np.arange(_dim.days) * 13),
+            (np.arange(200) * 13, False, np.arange(_dim.days) * 13),
+            # Test TxT
+            ((np.arange(_dim.days * _dim.days)).reshape((_dim.days, _dim.days)), True, None),
+            ((np.arange(_dim.days * _dim.days)).reshape((_dim.days, _dim.days)), False, None),
+            # Test higher dimension
+            (np.asarray([[42.0, 43.0, 44.0], [1.0, 2.0, 3.0]]), True, None),
+            (np.asarray([[42.0, 43.0, 44.0], [1.0, 2.0, 3.0]]), False, None),
+        ])
+
+    def test_adapt_node_and_node(self):
+        nxn = (_dim.nodes, _dim.nodes)
+        nxn_values = np.arange(_dim.nodes * _dim.nodes).reshape(nxn) + 42
+        self.adapt_test_framework(Shapes.NxN, [
+            # Test S
+            (np.asarray(42.0), True, np.full((nxn), 42.0)),
+            (np.asarray(42.0), False, None),
+            # Test < N (assume 4 to be less)
+            (np.arange(4), True, None),
+            (np.arange(4), False, None),
+            # Test > N (assume 10 to be greater)
+            (np.arange(10), True, None),
+            (np.arange(10), False, None),
+            # Test N
+            (np.arange(_dim.nodes), True, None),
+            (np.arange(_dim.nodes), False, None),
+            # Test NxN
+            (nxn_values.copy(), True, nxn_values),
+            (nxn_values.copy(), False, nxn_values),
+            # Test Nx10 and 10xN
+            (np.arange(_dim.nodes * 10).reshape((_dim.nodes, 10)), True, None),
+            (np.arange(_dim.nodes * 10).reshape((_dim.nodes, 10)), False, None),
+            (np.arange(_dim.nodes * 10).reshape((10, _dim.nodes)), True, None),
+            (np.arange(_dim.nodes * 10).reshape((10, _dim.nodes)), False, None),
+            # Test higher dimension
+            (np.arange(27).reshape((3, 3, 3)), True, None),
+            (np.arange(27).reshape((3, 3, 3)), False, None),
+        ])
+
+    def test_adapt_time_and_node(self):
+        txn = (_dim.days, _dim.nodes)
+        txt = (_dim.days, _dim.days)
+        nxn = (_dim.nodes, _dim.nodes)
+        txn_values = np.arange(_dim.days * _dim.nodes).reshape(txn) + 40
+        self.adapt_test_framework(Shapes.TxN, [
+            # Test S
+            (np.asarray(42.0), True, np.full((txn), 42.0)),
+            (np.asarray(42.0), False, None),
+            # Test < T and N (assume 4 to be less than either)
+            (np.arange(4), True, None),
+            (np.arange(4), False, None),
+            # T < Test < N (assume 32 to be between them)
+            (np.arange(32), True, None),
+            (np.arange(32), False, None),
+            # Test > T (assume 999 to be greater than either)
+            (np.arange(999), True, np.tile(np.arange(_dim.days), (_dim.nodes, 1)).T),
+            (np.arange(999), False, None),
+            # Test N
+            (np.arange(_dim.nodes), True, np.tile(np.arange(_dim.nodes), (_dim.days, 1))),
+            (np.arange(_dim.nodes), False, None),
+            # Test T
+            (np.arange(_dim.days), True, np.tile(np.arange(_dim.days), (_dim.nodes, 1)).T),
+            (np.arange(_dim.days), False, None),
+            # Test NxN
+            ((np.arange(_dim.nodes * _dim.nodes)).reshape(nxn), True, None),
+            ((np.arange(_dim.nodes * _dim.nodes)).reshape(nxn), False, None),
+            # Test TxT
+            ((np.arange(_dim.days * _dim.days)).reshape(txt), True, None),
+            ((np.arange(_dim.days * _dim.days)).reshape(txt), False, None),
+            # Test TxN
+            (txn_values.copy(), True, txn_values),
+            (txn_values.copy(), False, txn_values),
+            # Test higher dimension
+            (np.arange(27).reshape((3, 3, 3)), True, None),
+            (np.arange(27).reshape((3, 3, 3)), False, None),
+        ])
+
+    def test_adapt_abitrary(self):
+        # NOTE: A(2) is expecting to be able to access index 2 (as in `values[2]`)
+        # which implies our data must have at least 3 items.
+        self.adapt_test_framework(Shapes.A(2), [
+            # Test S
+            (np.asarray(42.0), True, None),
+            (np.asarray(42.0), False, None),
+            # Test 3
+            (np.array([42.0, 43.0, 44.0]), True, np.array([42.0, 43.0, 44.0])),
+            (np.array([42.0, 43.0, 44.0]), False, np.array([42.0, 43.0, 44.0])),
+            # Test 4
+            (np.array([42.0, 43.0, 44.0, 45.0]), True,
+             np.array([42.0, 43.0, 44.0, 45.0])),
+            (np.array([42.0, 43.0, 44.0, 45.0]), False,
+             np.array([42.0, 43.0, 44.0, 45.0])),
+            # Test higher dimensions
+            (np.arange(9).reshape((3, 3)), True, None),
+            (np.arange(9).reshape((3, 3)), False, None),
+            (np.arange(27).reshape((3, 3, 3)), True, None),
+            (np.arange(27).reshape((3, 3, 3)), False, None),
+        ])
+
+    def test_adapt_node_and_abitrary(self):
+        self.adapt_test_framework(Shapes.NxA(2), [
+            # Test S
+            (np.asarray(42.0), True, None),
+            (np.asarray(42.0), False, None),
+            # Test 3
+            (np.array([42.0, 43.0, 44.0]), True, np.tile(
+                np.array([42.0, 43.0, 44.0]), (_dim.nodes, 1))),
+            (np.array([42.0, 43.0, 44.0]), False, None),
+            # Test 4
+            (np.array([42.0, 43.0, 44.0, 45.0]), True, np.tile(
+                np.array([42.0, 43.0, 44.0, 45.0]), (_dim.nodes, 1))),
+            (np.array([42.0, 43.0, 44.0, 45.0]), False, None),
+            # Test other dimensions
+            (np.arange(9).reshape((3, 3)), True, None),
+            (np.arange(9).reshape((3, 3)), False, None),
+            (np.arange(27).reshape((3, 3, 3)), True, None),
+            (np.arange(27).reshape((3, 3, 3)), False, None),
+        ])
+
+    def test_adapt_time_and_abitrary(self):
+        tx3_values = np.arange(3 * _dim.days).reshape((_dim.days, 3))
+        self.adapt_test_framework(Shapes.TxA(2), [
+            # Test S
+            (np.asarray(42.0), True, None),
+            (np.asarray(42.0), False, None),
+            # Test 2
+            (np.arange(2), True, None),
+            (np.arange(2), False, None),
+            # Test 3
+            (np.arange(3), True, np.tile(np.arange(3), (_dim.days, 1))),
+            (np.arange(3), False, None),
+            # Test 4
+            (np.arange(4), True, np.tile(np.arange(4), (_dim.days, 1))),
+            (np.arange(4), False, None),
+            # Test Tx3
+            (tx3_values, True, tx3_values),
+            (tx3_values, False, tx3_values),
+            # Test (>T)x3
+            (np.arange(300 * 3).reshape((300, 3)), True, tx3_values),
+            (np.arange(300 * 3).reshape((300, 3)), False, tx3_values),
+            # Test other dimensions
+            (np.arange(9).reshape((3, 3)), True, None),
+            (np.arange(9).reshape((3, 3)), False, None),
+            (np.arange(27).reshape((3, 3, 3)), True, None),
+            (np.arange(27).reshape((3, 3, 3)), False, None),
+        ])
+
+    def test_adapt_time_and_node_and_abitrary(self):
+        txnx3_values = shaped_arange((_dim.days, _dim.nodes, 3))
+        self.adapt_test_framework(Shapes.TxNxA(2), [
+            # Test S
+            (np.asarray(42.0), True, None),
+            (np.asarray(42.0), False, None),
+            # Test 2
+            (np.arange(2), True, None),
+            (np.arange(2), False, None),
+            # Test 3
+            (np.arange(3), True, np.tile(np.arange(3), (_dim.days, _dim.nodes, 1))),
+            (np.arange(3), False, None),
+            # Test 4
+            (np.arange(4), True, np.tile(np.arange(4), (_dim.days, _dim.nodes, 1))),
+            (np.arange(4), False, None),
+            # Test Tx3
+            (txnx3_values, True, txnx3_values),
+            (txnx3_values, False, txnx3_values),
+            # Test (>T)x3
+            (shaped_arange((300, 3)), True, np.tile(
+                shaped_arange((_dim.days, 1, 3)), (1, _dim.nodes, 1))),
+            (shaped_arange((300, 3)), False, None),
+            # Test Nx3
+            (shaped_arange((_dim.nodes, 3)), True, np.tile(
+                shaped_arange((_dim.nodes, 3)), (_dim.days, 1, 1))),
+            (shaped_arange((_dim.nodes, 3)), False, None),
+            # Test (>N)x3
+            (shaped_arange((10, 3)), True, None),
+            (shaped_arange((10, 3)), False, None),
+            # Test (>T)xNx3
+            (shaped_arange((300, _dim.nodes, 3)), True, txnx3_values),
+            (shaped_arange((300, _dim.nodes, 3)), False, txnx3_values),
+            # Test Tx(>N)x3
+            (shaped_arange((_dim.days, 10, 3)), True, None),
+            (shaped_arange((_dim.days, 10, 3)), False, None),
+            # Test other dimensions
+            (shaped_arange((3, 3, 3, 3)), True, None),
+            (shaped_arange((3, 3, 3, 3)), False, None),
+        ])
 
 
 class TestParseShape(unittest.TestCase):


### PR DESCRIPTION
`DataShape.adapt()` would fail in some cases with some arguments, especially scalars. This fixes the code to be more robust for many different kinds of arguments.