### PR TITLE
Cache now supports reading and writing files as-is.

### DIFF
--- a/doc/devlog/README.md
+++ b/doc/devlog/README.md
@@ -48,6 +48,7 @@ This folder is a handy place to put Jupyter notebooks or other documents which h
 | 2024-03-13.ipynb | Tyler | | Showing off movement data collection (NEW!) |
 | 2024-04-04-draw-demo.ipynb | Izaac | | Showing the new draw module for visualising IPMs (NEW!) |
 | 2024-04-16.ipynb | Izaac | | Showing error handling for common ipm errors (NEW!)|
+| 2024-04-25.ipynb | Tyler | | Integration test: epymorph cache utilities |
 
 ## Contributing
 


### PR DESCRIPTION
That is, without bundling them in our tar format.
This doesn't allow for versioning, integrity checking, or file compression, but can be suitable for less volatile files that are already compressed. (And the devlog README I forgot to update.)