### PR TITLE
Fix too many sentinel values in CDC attributes.

### DIFF
--- a/doc/devlog/2024-07-03-cdc-adrio-demo.ipynb
+++ b/doc/devlog/2024-07-03-cdc-adrio-demo.ipynb
@@ -172,7 +172,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/waff/Desktop/CCL/Epymorph/epymorph/adrio/cdc.py:116: UserWarning: 6131 values < 4 were replaced with 0 in returned data.\n",
+      "/home/waff/Desktop/CCL/Epymorph/epymorph/adrio/cdc.py:117: UserWarning: 6131 values < 4 were replaced with 0 in returned data.\n",
       "  warn(\n"
      ]
     },
@@ -281,7 +281,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/waff/Desktop/CCL/Epymorph/epymorph/adrio/cdc.py:116: UserWarning: 1408 values < 4 were replaced with 0 in returned data.\n",
+      "/home/waff/Desktop/CCL/Epymorph/epymorph/adrio/cdc.py:117: UserWarning: 1408 values < 4 were replaced with 0 in returned data.\n",
       "  warn(\n"
      ]
     },
@@ -390,7 +390,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/waff/Desktop/CCL/Epymorph/epymorph/adrio/cdc.py:116: UserWarning: 4203 values < 4 were replaced with 0 in returned data.\n",
+      "/home/waff/Desktop/CCL/Epymorph/epymorph/adrio/cdc.py:117: UserWarning: 4203 values < 4 were replaced with 0 in returned data.\n",
       "  warn(\n"
      ]
     },
@@ -533,7 +533,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/waff/Desktop/CCL/Epymorph/epymorph/adrio/cdc.py:116: UserWarning: 1572 values < 4 were replaced with 0 in returned data.\n",
+      "/home/waff/Desktop/CCL/Epymorph/epymorph/adrio/cdc.py:117: UserWarning: 1572 values < 4 were replaced with 0 in returned data.\n",
       "  warn(\n"
      ]
     }


### PR DESCRIPTION
Address the concern of CDC attributes that pull data from the facility level hospitalization dataset returning large numbers of sentinel values by adding a replace_sentinel parameter to the attribute classes, allowing users to specify what the sentinel values will be replaced with. Also incorporates code reformatting based on Ruff linter suggestions in relevant files.