### PR TITLE
Fix bug constructing multistrata IPMs with exogenous classes.

### DIFF
--- a/epymorph/compartment_model.py
+++ b/epymorph/compartment_model.py
@@ -120,10 +120,12 @@ def _as_events(trxs: Iterable[TransitionDef]) -> Iterator[EdgeDef]:
 
 
 def _remap_edge(e: EdgeDef, symbol_mapping: dict[Symbol, Symbol]) -> EdgeDef:
+    f = symbol_mapping[x] if (x := e.compartment_from) not in exogenous_states else x
+    t = symbol_mapping[x] if (x := e.compartment_to) not in exogenous_states else x
     return EdgeDef(
         rate=substitute(e.rate, symbol_mapping),
-        compartment_from=symbol_mapping[e.compartment_from],
-        compartment_to=symbol_mapping[e.compartment_to],
+        compartment_from=f,
+        compartment_to=t,
     )
 
 

--- a/epymorph/rume.py
+++ b/epymorph/rume.py
@@ -460,7 +460,7 @@ class MultistrataRumeBuilder(ABC):
     """
 
     @abstractmethod
-    def meta_edges(self, symbols: MultistrataModelSymbols) -> list[TransitionDef]:
+    def meta_edges(self, symbols: MultistrataModelSymbols) -> Sequence[TransitionDef]:
         """
         When implementing a MultistrataRumeBuilder, override this method
         to build the meta-transition-edges -- the edges which represent


### PR DESCRIPTION
Also change MultistrataRumeBuilder.meta_edges to return a Sequence instead of a list for covariance reasons and interface consistency.