### PR TITLE
Remove ability to override a RUME's time frame.

### DIFF
--- a/epymorph/rume.py
+++ b/epymorph/rume.py
@@ -5,7 +5,6 @@ but will certainly not require less. A GPM (Geo-Population Model) is a subset of
 configuration, and it is possible to combine multiple GPMs into one multi-strata RUME.
 """
 
-import dataclasses
 import textwrap
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -18,7 +17,6 @@ from typing import (
     Mapping,
     NamedTuple,
     OrderedDict,
-    Self,
     Sequence,
     TypeVar,
     final,
@@ -403,14 +401,6 @@ class RUME(ABC, Generic[GeoScopeT_co]):
         simulation quantities.
         """
         return simulation_symbols(*symbols)
-
-    def with_time_frame(self, time_frame: TimeFrame) -> Self:
-        """Create a RUME with a new time frame."""
-        # TODO: do we need to go through all of the params and subset any
-        # that are time-based?
-        # How would that work? Or maybe reconciling to time frame happens
-        # at param evaluation time...
-        return dataclasses.replace(self, time_frame=time_frame)
 
     def estimate_data(
         self,

--- a/epymorph/simulator/basic/basic_simulator.py
+++ b/epymorph/simulator/basic/basic_simulator.py
@@ -23,7 +23,6 @@ from epymorph.simulator.basic.ipm_exec import IPMExecutor
 from epymorph.simulator.basic.mm_exec import MovementExecutor
 from epymorph.simulator.basic.output import Output
 from epymorph.simulator.world_list import ListWorld
-from epymorph.time import TimeFrame
 from epymorph.util import CovariantMapping
 
 _events = EventBus()
@@ -48,14 +47,11 @@ class BasicSimulator(Generic[RUMEType]):
         self,
         /,
         params: CovariantMapping[str | NamePattern, ParamValue] | None = None,
-        time_frame: TimeFrame | None = None,
         rng_factory: Callable[[], np.random.Generator] | None = None,
     ) -> Output[RUMEType]:
         """Run a RUME with the given overrides."""
 
         rume = self.rume
-        if time_frame is not None:
-            rume = rume.with_time_frame(time_frame)
 
         rng = (rng_factory or np.random.default_rng)()
 


### PR DESCRIPTION
Parameters specified as numpy arrays with a time axis were not being handled as expected when using this feature. Values were always used starting with time-index 0, even when that time index corresponds to different calendar days. As time is short to fix this, removing the (mostly unused) feature is preferable.