### PR TITLE
Error message improvement for invalid selections.

### DIFF
--- a/epymorph/time.py
+++ b/epymorph/time.py
@@ -874,7 +874,7 @@ class TimeSelector:
         TimeSelection
             The selection strategy object.
         """
-        return TimeSelection(self.time_frame, (slice(from_day, to_day), step))
+        return TimeSelection(self.time_frame, (slice(from_day, to_day + 1), step))
 
     def range(
         self,

--- a/epymorph/tools/data.py
+++ b/epymorph/tools/data.py
@@ -47,20 +47,35 @@ def _validate(
     # try to render a table using a selection on a completely different scope.
     if geo.scope is not output.rume.scope:
         err = (
-            "When applying a geo selection, please create that selection "
-            "from the same scope you are applying it to."
+            "When applying a geo selection to an output, both selection and "
+            "output must reference the same GeoScope instance.\n"
+            "In this case:\n"
+            f"  selection references {object.__repr__(geo.scope)}\n"
+            f"     output references {object.__repr__(output.rume.scope)}\n"
+            "You might fix this by selecting from the output's RUME's scope, "
+            "e.g.: `out.rume.scope.select.all()`"
         )
         raise ValueError(err)
     if time.time_frame is not output.rume.time_frame:
         err = (
-            "When applying a time selection, please create that selection "
-            "from the same time frame you are applying it to."
+            "When applying a time frame selection to an output, both selection and "
+            "output must reference the same TimeFrame instance.\n"
+            "In this case:\n"
+            f"  selection references {object.__repr__(time.time_frame)}\n"
+            f"     output references {object.__repr__(output.rume.time_frame)}\n"
+            "You might fix this by selecting from the output's RUME's time frame, "
+            "e.g.: `out.rume.time_frame.select.all()`"
         )
         raise ValueError(err)
     if quantity.ipm is not output.rume.ipm:
         err = (
-            "When applying an IPM quantity selection, please create that selection "
-            "from the same IPM you are applying it to."
+            "When applying an IPM quantity selection to an output, both selection and "
+            "output must reference the same IPM instance.\n"
+            "In this case:\n"
+            f"  selection references {object.__repr__(quantity.ipm)}\n"
+            f"     output references {object.__repr__(output.rume.ipm)}\n"
+            "You might fix this by selecting from the output's RUME's IPM, "
+            "e.g.: `out.rume.ipm.select.events()`"
         )
         raise ValueError(err)
 

--- a/epymorph/tools/data.py
+++ b/epymorph/tools/data.py
@@ -70,7 +70,7 @@ def _validate(
     if quantity.ipm is not output.rume.ipm:
         err = (
             "When applying an IPM quantity selection to an output, both selection and "
-            "output must reference the same IPM instance.\n"
+            "output must reference the same CompartmentModel instance.\n"
             "In this case:\n"
             f"  selection references {object.__repr__(quantity.ipm)}\n"
             f"     output references {object.__repr__(output.rume.ipm)}\n"

--- a/tests/fast/tools/data_test.py
+++ b/tests/fast/tools/data_test.py
@@ -1,0 +1,119 @@
+from dataclasses import dataclass
+from datetime import date
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from epymorph import initializer as init
+from epymorph.data import ipm, mm
+from epymorph.geography.us_census import StateScope
+from epymorph.rume import RUME, SingleStrataRUME
+from epymorph.time import TimeFrame
+from epymorph.tools.data import Output, munge
+
+
+@pytest.fixture
+def rume() -> RUME[StateScope]:
+    """A very simple RUME with no external data requirements."""
+    return SingleStrataRUME.build(
+        ipm=ipm.SIRS(),
+        mm=mm.No(),
+        init=init.SingleLocation(location=0, seed_size=100),
+        scope=StateScope.in_states(["04", "35"], year=2020),
+        time_frame=TimeFrame.of("2021-01-01", 4),
+        params={
+            "beta": 0.4,
+            "gamma": 1 / 10,
+            "xi": 1 / 90,
+            "population": [200_000, 100_000],
+        },
+    )
+
+
+@pytest.fixture
+def output(rume: RUME[StateScope]) -> Output:
+    """A mock output so we don't have to run a sim."""
+
+    @dataclass
+    class MockOutput(Output):
+        rume: RUME
+        data_df: pd.DataFrame
+
+        @property
+        def dataframe(self) -> pd.DataFrame:
+            return self.data_df
+
+    return MockOutput(
+        rume,
+        pd.DataFrame(
+            {
+                "tick": np.repeat(np.arange(0, 4), 2),
+                "date": np.repeat(np.arange(date(2021, 1, 1), date(2021, 1, 5)), 2),
+                "node": np.tile(["04", "35"], 4),
+                "S": np.arange(3000, 3800, 100),
+                "I": np.arange(2000, 2800, 100),
+                "R": np.arange(1000, 1800, 100),
+                "S → I": np.arange(300, 380, 10),
+                "I → R": np.arange(200, 280, 10),
+                "R → S": np.arange(100, 180, 10),
+            }
+        ),
+    )
+
+
+def test_basic_munge(rume, output):
+    # Test with a selection in each axis.
+    actual = munge(
+        output=output,
+        geo=rume.scope.select.by_state("04"),
+        time=rume.time_frame.select.days(1, 2),
+        quantity=rume.ipm.select.compartments(),
+    )
+
+    expected = pd.DataFrame(
+        {
+            "time": [1, 2],
+            "geo": ["04", "04"],
+            "S": [3200, 3400],
+            "I": [2200, 2400],
+            "R": [1200, 1400],
+        }
+    )
+
+    pd.testing.assert_frame_equal(actual.reset_index(drop=True), expected)
+
+
+def test_munge_errors(rume, output):
+    # Bad object correlation, geo
+    wrong_geo = StateScope.in_states(["08"], year=2021)
+    with pytest.raises(ValueError) as err:  # noqa: PT011
+        munge(
+            output=output,
+            geo=wrong_geo.select.all(),
+            time=rume.time_frame.select.all(),
+            quantity=rume.ipm.select.compartments(),
+        )
+    assert "same GeoScope instance" in str(err.value)
+
+    # Bad object correlation, time
+    wrong_time = TimeFrame.rangex("2021-01-01", "2021-02-01")
+    with pytest.raises(ValueError) as err:  # noqa: PT011
+        munge(
+            output=output,
+            geo=rume.scope.select.all(),
+            time=wrong_time.select.all(),
+            quantity=rume.ipm.select.compartments(),
+        )
+    assert "same TimeFrame instance" in str(err.value)
+
+    # Bad object correlation, quantity
+    wrong_ipm = ipm.SIRH()
+    with pytest.raises(ValueError) as err:  # noqa: PT011
+        munge(
+            output=output,
+            geo=rume.scope.select.all(),
+            time=rume.time_frame.select.all(),
+            quantity=wrong_ipm.select.compartments(),
+        )
+    assert "same CompartmentModel instance" in str(err.value)


### PR DESCRIPTION
Error messages for this issue now read like:

```
ValueError: When applying an IPM quantity selection to an output, both selection and output must reference the same IPM instance.
In this case:
  selection references <__main__.BSIRD object at 0x7f7fab28d310>
     output references <__main__.BSIRD object at 0x7f7fab28c190>
You might fix this by selecting from the output's RUME's IPM, e.g.: `out.rume.ipm.select.events()`
```