### PR TITLE
Fix error message when there are parameter evaluation issues.

### DIFF
--- a/epymorph/simulator/basic/basic_simulator.py
+++ b/epymorph/simulator/basic/basic_simulator.py
@@ -87,13 +87,14 @@ class BasicSimulator(Generic[RUMEType]):
             try:
                 data = rume.evaluate_params(override_params=params, rng=rng)
             except DataAttributeError as e:
-                msg = f"RUME attribute requirements were not met. See errors:\n- {e}"
-                raise SimValidationError(msg) from None
-            except ExceptionGroup as e:
-                msg = "RUME attribute requirements were not met. See errors:" + "".join(
-                    f"\n- {e}" for e in e.exceptions
+                sub_es = e.exceptions if isinstance(e, ExceptionGroup) else (e,)
+                err = "\n".join(
+                    [
+                        "RUME attribute requirements were not met. See errors:",
+                        *(f"- {e}" for e in sub_es),
+                    ]
                 )
-                raise SimValidationError(msg) from None
+                raise SimValidationError(err) from None
 
         with error_gate("initializing the simulation", InitError):
             initial_values = rume.initialize(data, rng)


### PR DESCRIPTION
After this change, error messages read as intended.

For the example where beta is given as an array of 2 values when N is 4:

```
Traceback (most recent call last):
  File "/home/tcoles/Workspaces/Epymorph2/.venv/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3577, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "/tmp/ipykernel_10988/3073044865.py", line 22, in <module>
    sim.run()
  File "/home/tcoles/Workspaces/Epymorph2/epymorph/simulator/basic/basic_simulator.py", line 97, in run
    raise SimValidationError(err) from None
epymorph.error.SimValidationError: RUME attribute requirements were not met. See errors:
- Attribute 'gpm:all::ipm::beta' (parameter value '*::ipm::beta') is not properly specified: Not a compatible shape.
```