### PR TITLE
ADRIO minor improvements.

### DIFF
--- a/epymorph/adrio/acs5.py
+++ b/epymorph/adrio/acs5.py
@@ -695,6 +695,34 @@ class PopulationByAge(ADRIO[np.int64, np.int64]):
             issues={},
         )
 
+    @staticmethod
+    def age_ranges(year: int) -> Sequence[AgeRange]:
+        """
+        Lists the AgeRanges used by the ACS5 population by age table in definition order
+        for the given year. Note that this does not correspond one-to-one with the
+        values in the B01001 table -- this list omits "total" columns and duplicates.
+
+        This is a static method.
+
+        Parameters
+        ----------
+        year : int
+            A supported ACS5 year.
+
+        Returns
+        -------
+        Sequence[AgeRange]
+            The age ranges.
+        """
+        return filter_unique(
+            x
+            for x in (
+                AgeRange.parse(attrs["label"])
+                for _, attrs in ACS5Client.get_group_vars(year, "B01001")
+            )
+            if x is not None
+        )
+
 
 # fmt: off
 RaceCategory = Literal["White", "Black", "Native", "Asian", "Pacific Islander", "Other", "Multiple"]  # noqa: E501

--- a/epymorph/adrio/acs5.py
+++ b/epymorph/adrio/acs5.py
@@ -304,6 +304,9 @@ def _get_scope(adrio: ADRIO, context: Context) -> CensusScope:
     if context.scope.year not in ACS5_YEARS:
         err = f"{context.scope.year} is not a supported year for ACS5 data."
         raise ADRIOContextError(adrio, context, err)
+    if isinstance(context.scope, BlockGroupScope) and context.scope.year <= 2012:
+        err = "Block group ACS5 data is not available via this API for 2012 or prior."
+        raise ADRIOContextError(adrio, context, err)
     return context.scope
 
 

--- a/epymorph/adrio/acs5.py
+++ b/epymorph/adrio/acs5.py
@@ -574,7 +574,7 @@ class AgeRange(NamedTuple):
             end = start
         elif (m := _under_pattern.match(bracket)) is not None:
             start = 0
-            end = int(m.group(1))
+            end = int(m.group(1)) - 1
         elif (m := _range_pattern.match(bracket)) is not None:
             start = int(m.group(1))
             end = int(m.group(2))

--- a/epymorph/util.py
+++ b/epymorph/util.py
@@ -160,18 +160,6 @@ def index_of(it: Iterable[T], item: T) -> int:
     return -1
 
 
-def iterator_length(it: Iterable[Any]) -> int:
-    """
-    Count the number of items in the given iterator.
-    Warning: this consumes the iterator!
-    It also never terminates if the iterator is infinite.
-    """
-    length = 0
-    for _ in it:
-        length += 1
-    return length
-
-
 def list_not_none(it: Iterable[T | None]) -> list[T]:
     """Convert an iterable to a list, skipping any entries that are None."""
     return [x for x in it if x is not None]

--- a/tests/fast/time_test.py
+++ b/tests/fast/time_test.py
@@ -78,12 +78,22 @@ def test_date_range_to_pandas():
     pd.testing.assert_index_equal(actual, expected)
 
 
+def test_date_range_between_same_dates():
+    d = DateRange(date(2025, 1, 1), date(2025, 1, 29), step=7)
+    actual = d.between(min_date=date(2025, 1, 1), max_date=date(2025, 1, 29))
+    assert actual is not None
+    assert actual.start_date == date(2025, 1, 1)
+    assert actual.end_date == date(2025, 1, 29)
+    assert actual.step == 7
+
+
 def test_date_range_between_within_step():
     d = DateRange(date(2025, 1, 1), date(2025, 1, 29), step=7)
     actual = d.between(min_date=date(2025, 1, 8), max_date=date(2025, 1, 22))
     assert actual is not None
     assert actual.start_date == date(2025, 1, 8)
     assert actual.end_date == date(2025, 1, 22)
+    assert actual.step == 7
 
 
 def test_date_range_between_outside_step():
@@ -92,6 +102,7 @@ def test_date_range_between_outside_step():
     assert actual is not None
     assert actual.start_date == date(2025, 1, 8)
     assert actual.end_date == date(2025, 1, 22)
+    assert actual.step == 7
 
 
 def test_date_range_between_no_change():
@@ -100,6 +111,7 @@ def test_date_range_between_no_change():
     assert actual is not None
     assert actual.start_date == date(2025, 1, 1)
     assert actual.end_date == date(2025, 1, 29)
+    assert actual.step == 7
 
 
 def test_date_range_between_min_date_after_max_date():


### PR DESCRIPTION
- Fix ACS5 age range parsing bug ("under X" was being parsed as "X" instead of "X-1")
- Add function to list ACS5 age ranges
- Add validation check to ACS5: raise context error if trying to load data at CBG granularity for 2012 or prior -- the Census API does not support this so this was previously an error during fetch, but better to catch it early with a better description
- ADRIO docstring improvements