### PR TITLE
Clipping fix to underflow.

### DIFF
--- a/epymorph/data/mm/centroids.py
+++ b/epymorph/data/mm/centroids.py
@@ -55,7 +55,9 @@ class CentroidsClause(MovementClause):
         centroid = self.data("centroid")
         phi = self.data("phi")
         distance = pairwise_haversine(centroid)
-        return row_normalize(1 / np.exp(distance / phi))
+        prob = np.exp(-np.clip(distance/phi,a_max = 100.,a_min = None))
+        return row_normalize(prob)
+
 
     def evaluate(self, tick: Tick) -> NDArray[np.int64]:
         pop = self.data("population")

--- a/epymorph/data/mm/centroids.py
+++ b/epymorph/data/mm/centroids.py
@@ -55,9 +55,8 @@ class CentroidsClause(MovementClause):
         centroid = self.data("centroid")
         phi = self.data("phi")
         distance = pairwise_haversine(centroid)
-        prob = np.exp(-np.clip(distance/phi,a_max = 100.,a_min = None))
+        prob = 1 / np.exp(distance / phi)
         return row_normalize(prob)
-
 
     def evaluate(self, tick: Tick) -> NDArray[np.int64]:
         pop = self.data("population")

--- a/epymorph/data/mm/centroids.py
+++ b/epymorph/data/mm/centroids.py
@@ -55,7 +55,7 @@ class CentroidsClause(MovementClause):
         centroid = self.data("centroid")
         phi = self.data("phi")
         distance = pairwise_haversine(centroid)
-        prob = 1 / np.exp(distance / phi)
+        prob = np.exp(-np.clip(distance / phi, a_min=None, a_max=100.0))
         return row_normalize(prob)
 
     def evaluate(self, tick: Tick) -> NDArray[np.int64]:

--- a/epymorph/data/mm/centroids.py
+++ b/epymorph/data/mm/centroids.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from epymorph.attribute import AttributeDef
 from epymorph.data_shape import Shapes
 from epymorph.data_type import CentroidType, SimDType
+from epymorph.error import DataAttributeError
 from epymorph.movement_model import EveryDay, MovementClause, MovementModel
 from epymorph.simulation import Tick, TickDelta, TickIndex
 from epymorph.util import pairwise_haversine, row_normalize
@@ -54,13 +55,26 @@ class CentroidsClause(MovementClause):
         """
         centroid = self.data("centroid")
         phi = self.data("phi")
+        if phi <= 0:
+            err = "Centroids movement model parameter 'phi' must be positive."
+            raise DataAttributeError(err)
+        # np.exp(-x) can overflow if x is too large, so we clip to a maximum of 700;
+        #   np.exp(-700) is approximately 5e-305, which is close to the smallest
+        #   possible positive float64 value.
         distance = pairwise_haversine(centroid)
-        prob = np.exp(-np.clip(distance / phi, a_min=None, a_max=100.0))
+        dist_over_phi = np.clip(distance / phi, a_min=None, a_max=700.0)
+        prob = np.exp(-dist_over_phi)
         return row_normalize(prob)
 
     def evaluate(self, tick: Tick) -> NDArray[np.int64]:
         pop = self.data("population")
         comm_prop = self.data("commuter_proportion")
+        if comm_prop < 0:
+            err = (
+                "Centroids movement model parameter 'commuter_proportion' must be "
+                "greater than or equal to zero."
+            )
+            raise DataAttributeError(err)
         n_commuters = np.floor(pop * comm_prop).astype(SimDType)
         return self.rng.multinomial(n_commuters, self.dispersal_kernel)
 

--- a/tests/fast/data/mm/centroids_test.py
+++ b/tests/fast/data/mm/centroids_test.py
@@ -1,0 +1,111 @@
+"""
+Test Centroids movement model for limitations.
+"""
+
+from datetime import date
+
+import numpy as np
+import pytest
+
+from epymorph.data.mm.centroids import CentroidsClause
+from epymorph.data_type import CentroidDType
+from epymorph.error import DataAttributeError
+from epymorph.geography.custom import CustomScope
+from epymorph.simulation import Tick
+
+_SCOPE = CustomScope(["Flagstaff", "Phoenix", "Tucson"])
+_CENTROIDS = np.array(
+    [
+        (-111.651, 35.198),  # Flagstaff
+        (-112.074, 33.448),  # Phoenix
+        (-110.974, 32.222),  # Tucson
+    ],
+    dtype=CentroidDType,
+)
+_POPULATION = np.array([10000, 20000, 30000], dtype=np.int64)
+_TICK = Tick(sim_index=0, day=0, date=date(2020, 1, 1), step=0, tau=1 / 3)
+
+
+def _make_clause(phi: float, commuter_proportion: float = 0.1) -> CentroidsClause:
+    return CentroidsClause().with_context(
+        scope=_SCOPE,
+        params={
+            "population": _POPULATION,
+            "centroid": _CENTROIDS,
+            "phi": phi,
+            "commuter_proportion": commuter_proportion,
+        },
+        rng=np.random.default_rng(42),
+    )
+
+
+def test_evaluate():
+    commuter_proportion = 0.1
+    clause = _make_clause(phi=40.0, commuter_proportion=commuter_proportion)
+    result = clause.evaluate(_TICK)
+
+    assert result.shape == (3, 3)
+    assert np.all(result >= 0)
+
+    # multinomial distributes exactly n_commuters[i] draws per row i
+    expected_movers = np.floor(_POPULATION * commuter_proportion)
+    actual_movers = result.sum(axis=1)
+    np.testing.assert_array_equal(actual_movers, expected_movers)
+
+
+def test_phi_zero_error():
+    clause = _make_clause(phi=0.0)
+    with pytest.raises(DataAttributeError, match="phi"):
+        clause.evaluate(_TICK)
+
+
+def test_phi_negative_error():
+    clause = _make_clause(phi=-5.0)
+    with pytest.raises(DataAttributeError, match="phi"):
+        clause.evaluate(_TICK)
+
+
+def test_commuter_proportion_negative_error():
+    clause = _make_clause(phi=40.0, commuter_proportion=-0.1)
+    with pytest.raises(DataAttributeError, match="commuter_proportion"):
+        clause.evaluate(_TICK)
+
+
+def test_small_phi_no_underflow():
+    """
+    Very small phi causes distance/phi > 700. This can cause np.exp(-x) to underflow,
+    raising an error. So instead we clip distance/phi so that the dispersal kernel
+    values can be as close as possible to 0 without causing an error.
+    """
+    clause = _make_clause(phi=0.001)
+    kernel = clause.dispersal_kernel
+
+    # No NaNs of Infs
+    assert not np.any(np.isnan(kernel)), "kernel contains NaN"
+    assert not np.any(np.isinf(kernel)), "kernel contains Inf"
+
+    # No zero-values demonstrates underflow prevention is working
+    assert np.all(kernel > 0), (
+        "Dispersal kernel should be all > 0 (clip prevented underflow)"
+    )
+
+    # Row-sums should equal 1 (row_normalize worked correctly)
+    np.testing.assert_allclose(kernel.sum(axis=1), np.ones(3), atol=1e-10)
+
+
+def test_kernel_decreases_with_distance():
+    """Test: dispersal probability decreases as distance increases."""
+    clause = _make_clause(phi=40.0)
+    kernel = clause.dispersal_kernel
+
+    # pairwise distances for the centroids (in miles):
+    #   [  0.   , 123.436, 209.503]  # noqa: ERA001
+    #   [123.436,   0.   , 106.200]  # noqa: ERA001
+    #   [209.503, 106.200,   0.   ]  # noqa: ERA001
+
+    # From Flagstaff: Phoenix should be preferred over Tucson
+    assert kernel[0, 1] > kernel[0, 2]
+    # From Phoenix: Tucson should be preferred over Flagstaff
+    assert kernel[1, 2] > kernel[1, 0]
+    # From Tucson: Phoenix should be preferred over Flagstaff
+    assert kernel[2, 1] > kernel[2, 0]


### PR DESCRIPTION
Fixes the associated issue with probability of movement underflowing in `mm.centroids`. Probability of movement is now clamped to a minimum of $e^{-100} \approx 2.68 \times 10^{-43}$. This is close enough to zero that it shouldn't affect any simulation results. We should put a warning in the docs that `mm.centroids` is not well suited to the state level spatial scale. 